### PR TITLE
Include LICENSE.txt in source distributions so wheels can be created

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt


### PR DESCRIPTION
I tried building a new wheel from the PyPI source distribution and it fails. The reason is that `setup.cfg`  needs `LICENSE.txt` and it's not present. 

The error I got:

```
error: [Errno 2] No such file or directory: 'LICENSE.txt'
```


This commit makes it so the license file is included in the source distribution.

How I tested it:

```
$ python3.6 setup.py sdist
$ tar -xf dist/icecream-1.4.0.tar.gz
$ cd icecream-1.4.0/
$ python3.6 setup.py bdist_wheel
# It works.
```
