### PR TITLE
Use the library `executing`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 sudo: false
 matrix:
   include:
-    - env: TOXENV=codestyle
-
     - python: 2.7
       env: TOXENV=py27
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from os.path import basename
 
 import colorama
-from executing_node import Source
+from executing import Source
 from pygments import highlight
 # See https://gist.github.com/XVilka/8346728 for color support in various
 # terminals and thus whether to use Terminal256Formatter or
@@ -215,9 +215,8 @@ class IceCreamDebugger:
     def _format(self, callFrame, *args):
         prefix = callOrValue(self.prefix)
 
-        try:
-            callNode = Source.executing_node(callFrame)
-        except Exception:
+        callNode = Source.executing(callFrame).node
+        if callNode is None:
             raise NoSourceAvailableError()
 
         context = self._formatContext(callFrame, callNode)

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -112,8 +112,6 @@ class Source(executing.Source):
             result = ' ' * node.first_token.start[1] + result
             result = dedent(result)
         result = result.strip()
-        if isinstance(node, ast.Tuple) and result[0] + result[-1] != '()':
-            result = '(' + prefixLinesAfterFirst(' ', result) + ')'
         return result
 
 

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -13,6 +13,7 @@
 
 from __future__ import print_function
 
+import ast
 import inspect
 import pprint
 import sys
@@ -117,8 +118,9 @@ class Source(executing.Source):
         if '\n' in result:
             result = ' ' * node.first_token.start[1] + result
             result = dedent(result)
-        else:
-            result = result.strip()
+        result = result.strip()
+        if isinstance(node, ast.Tuple) and result[0] + result[-1] != '()':
+            result = '(' + prefixLinesAfterFirst(' ', result) + ')'
         return result
 
 

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -31,13 +31,6 @@ from pygments import highlight
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import PythonLexer as PyLexer, Python3Lexer as Py3Lexer
 
-# Avoid a dependency on six (https://pythonhosted.org/six/) for just
-# one import.
-try:
-    from StringIO import StringIO  # Python 2.
-except ImportError:
-    from io import StringIO  # Python 3.
-
 from .coloring import SolarizedDark
 
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
@@ -102,9 +103,8 @@ setup(
     install_requires=[
         'colorama>=0.3.9',
         'pygments>=2.2.0',
-        'untokenize>=0.1.1',
-        'executing',
-        'asttokens',
+        'executing>=0.3.1',
+        'asttokens>=2.0.1',
     ],
     cmdclass={
         'test': RunTests,

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,8 @@ setup(
         'colorama>=0.3.9',
         'pygments>=2.2.0',
         'untokenize>=0.1.1',
+        'executing',
+        'asttokens',
     ],
     cmdclass={
         'test': RunTests,

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -467,21 +467,41 @@ class TestIceCream(unittest.TestCase):
                 b))
             ic([a,
                 b])
-        print(err.getvalue())
+            ic((a,
+                b),
+               [list(range(15)),
+                list(range(15))])
 
-        pairs = parseOutputIntoPairs(out, err, 2)
-        assert pairs[0][0] == ('(a, b)', '(1, 2)')
-        assert pairs[1][0] == ('[a, b]', '[1, 2]')
+        self.assertEqual(err.getvalue().strip(), """
+ic| a,
+    b: (1, 2)
+ic| [a,
+     b]: [1, 2]
+ic| a,
+    b: (1, 2)
+    [list(range(15)),
+     list(range(15))]: [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+                        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]]
+        """.strip())
 
-    def testWhitespaceCollapsing(self):
         with disableColoring(), captureStandardStreams() as (out, err):
-            ic(  a,     noop(   a  , b   ),   [   a,  # noqa
-                                                      b  ])  # noqa
+            with configureIcecreamOutput(includeContext=True):
+                ic((a,
+                    b),
+                   [list(range(15)),
+                    list(range(15))])
 
-        print(err.getvalue())
-        pairs = parseOutputIntoPairs(out, err, 1)[0]
-        assert pairs == [
-            ('a', '1'), ('noop(a, b)', 'None'), ('[a, b]', '[1, 2]')]
+        lines = err.getvalue().strip().splitlines()
+        self.assertRegexpMatches(
+            lines[0],
+            r'ic\| test_icecream.py:\d+ in testMultilineContainerArgs\(\)',
+        )
+        self.assertEqual('\n'.join(lines[1:]), """\
+    a,
+    b: (1, 2)
+    [list(range(15)),
+     list(range(15))]: [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+                        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]]""")
 
     def testMultipleTupleArguments(self):
         with disableColoring(), captureStandardStreams() as (out, err):

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -508,7 +508,6 @@ ic| (a,
             ic((a, b), (b, a), a, b)
 
         pair = parseOutputIntoPairs(out, err, 1)[0]
-        # fail because of https://github.com/gristlabs/asttokens/issues/11
         self.assertEqual(pair, [
             ('(a, b)', '(1, 2)'), ('(b, a)', '(2, 1)'), ('a', '1'), ('b', '2')])
 

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -459,7 +459,7 @@ class TestIceCream(unittest.TestCase):
             ic((a, b))
 
         pair = parseOutputIntoPairs(out, err, 1)[0][0]
-        assert pair == ('(a, b)', '(1, 2)')
+        self.assertEqual(pair, ('(a, b)', '(1, 2)'))
 
     def testMultilineContainerArgs(self):
         with disableColoring(), captureStandardStreams() as (out, err):
@@ -467,6 +467,7 @@ class TestIceCream(unittest.TestCase):
                 b))
             ic([a,
                 b])
+        print(err.getvalue())
 
         pairs = parseOutputIntoPairs(out, err, 2)
         assert pairs[0][0] == ('(a, b)', '(1, 2)')
@@ -477,6 +478,7 @@ class TestIceCream(unittest.TestCase):
             ic(  a,     noop(   a  , b   ),   [   a,  # noqa
                                                       b  ])  # noqa
 
+        print(err.getvalue())
         pairs = parseOutputIntoPairs(out, err, 1)[0]
         assert pairs == [
             ('a', '1'), ('noop(a, b)', 'None'), ('[a, b]', '[1, 2]')]
@@ -486,8 +488,9 @@ class TestIceCream(unittest.TestCase):
             ic((a, b), (b, a), a, b)
 
         pair = parseOutputIntoPairs(out, err, 1)[0]
-        assert pair == [
-            ('(a, b)', '(1, 2)'), ('(b, a)', '(2, 1)'), ('a', '1'), ('b', '2')]
+        # fail because of https://github.com/gristlabs/asttokens/issues/11
+        self.assertEqual(pair, [
+            ('(a, b)', '(1, 2)'), ('(b, a)', '(2, 1)'), ('a', '1'), ('b', '2')])
 
     def testColoring(self):
         with captureStandardStreams() as (out, err):

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -473,12 +473,12 @@ class TestIceCream(unittest.TestCase):
                 list(range(15))])
 
         self.assertEqual(err.getvalue().strip(), """
-ic| a,
-    b: (1, 2)
+ic| (a,
+     b): (1, 2)
 ic| [a,
      b]: [1, 2]
-ic| a,
-    b: (1, 2)
+ic| (a,
+     b): (1, 2)
     [list(range(15)),
      list(range(15))]: [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
                         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]]
@@ -497,8 +497,8 @@ ic| a,
             r'ic\| test_icecream.py:\d+ in testMultilineContainerArgs\(\)',
         )
         self.assertEqual('\n'.join(lines[1:]), """\
-    a,
-    b: (1, 2)
+    (a,
+     b): (1, 2)
     [list(range(15)),
      list(range(15))]: [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
                         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]]""")

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
-envlist = codestyle, py27, py34, py35, py36, py37, pypy, pypy3
+envlist = py27, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps =
     nose
 commands =
     nosetests --exe []
-
-[testenv:codestyle]
-deps = flake8
-commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3
+envlist = py27, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Hi!

I wanted to integrate this library's functionality into my own project, so I looked into how it worked, and discovered that in many cases it didn't. Here's a quick script showing various cases in which it fails. They all work after this PR.

```python
from icecream import ic


def main():
    x = 1
    (
        ic(x))

    if ic(x):
        pass

    ic([ic(x)])
    {ic(x) for x in ic([1, 2])}
    list(ic(x) for x in [1, 2])
    (lambda: ic(x))()
    return ic(x)


main()
```

I tried to fix the algorithm, but slowly discovered more and more that it was fundamentally broken. In the end all that's left is the general idea of analysing the bytecode and using `frame.f_lasti`. But I want to emphasise that even this was a big leap, and what you accomplished was very impressive. I didn't know that this was a solvable problem. Your code inspired me and set me in the right direction to create something very cool with broad potential applications.

The new algorithm now lives in a new general purpose little package I've created called [`executing`](https://github.com/alexmojaki/executing). It finds the AST node corresponding to the `ic()` call. Translating that into source code is done with [`asttokens`](https://github.com/gristlabs/asttokens), which is the best method I know of. Unfortunately it comes with a couple of small problems:

1. Python 3.4 is not supported.
2. The source code for tuples doesn't include surrounding parentheses, e.g. `ic((1, 2))` just gives `1, 2` as the source, which is causing some failures. If you want to fix this, take a look at https://github.com/gristlabs/asttokens/issues/11

There's also some failures because `collapseWhitespaceBetweenTokens` doesn't seem to be doing what the name suggests. Personally I don't think the displayed source code should be modified anyway. If you still want to do that, you'll have to figure out how.

Some other perks:

1. Caching make repeated calls very fast.
2. Files with encoding declarations are decoded correctly.
3. It works in IPython shells and notebooks.
4. `icecream.ic()` works. In fact `ic` can be the result of any expression.
