### PR TITLE
Convert colorama into an optional dependency

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -13,16 +13,13 @@
 
 from __future__ import print_function
 
-import ast
 import inspect
 import pprint
 import sys
-from contextlib import contextmanager
 from datetime import datetime
 from os.path import basename
 from textwrap import dedent
 
-import colorama
 import executing
 from pygments import highlight
 # See https://gist.github.com/XVilka/8346728 for color support in various
@@ -33,6 +30,10 @@ from pygments.lexers import PythonLexer as PyLexer, Python3Lexer as Py3Lexer
 
 from .coloring import SolarizedDark
 
+if sys.platform.startswith('win'):
+    # We will import colorama only on a specific subset of OS's thus removing colorama from required dependencies
+    import colorama
+    colorama.init()
 
 PYTHON2 = (sys.version_info[0] == 2)
 
@@ -55,23 +56,13 @@ def colorize(s):
     return highlight(s, self.lexer, self.formatter)
 
 
-@contextmanager
-def supportTerminalColorsInWindows():
-    # Filter and replace ANSI escape sequences on Windows with equivalent Win32
-    # API calls. This code does nothing on non-Windows systems.
-    colorama.init()
-    yield
-    colorama.deinit()
-
-
 def stderrPrint(*args):
     print(*args, file=sys.stderr)
 
 
 def colorizedStderrPrint(s):
     colored = colorize(s)
-    with supportTerminalColorsInWindows():
-        stderrPrint(colored)
+    stderrPrint(colored)
 
 
 DEFAULT_PREFIX = 'ic| '

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     ],
     tests_require=[],
     install_requires=[
-        'colorama>=0.3.9',
+        'colorama>=0.3.9; platform_system=="Windows"',
         'pygments>=2.2.0',
         'executing>=0.3.1',
         'asttokens>=2.0.1',


### PR DESCRIPTION
I propose an update to the list of dependecies required to use `ic`.

Right now, we have to install `colorama` on all platforms, despite the fact that `ic` will run properly on some operating systems even without `colorama` presented.

As stated, I suggest: 
* Converting colorama into an optional dependecy;
* Wrapping colorama import and initialization in a platform-dependent if-block;
* Some refactoring to the icecream.py;