### PR TITLE
feat(fstring): treat fstring as string literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ except ImportError:  # Graceful fallback if IceCream isn't installed.
 ### Configuration
 
 `ic.configureOutput(prefix, outputFunction, argToStringFunction,
-includeContext)` can be used to adopt a custom output prefix (the default is
-`ic| `), change the output function (default is to write to stderr), customize
-how arguments are serialized to strings, and/or include the `ic()` call's
-context (filename, line number, and parent function) in `ic()` output with
-arguments.
+includeContext, includeFStringExpressions)` can be used to adopt a custom 
+output prefix (the default is `ic| `), change the output function (default is 
+to write to stderr), customize how arguments are serialized to strings, 
+and/or include the `ic()` call's context (filename, line number, 
+and parent function) in `ic()` output with arguments.
 
 ```pycon
 >>> from icecream import ic
@@ -307,6 +307,25 @@ ic| example.py:12 in foo()- 'str': 'str'
 
 `includeContext` is False by default.
 
+`includeFStringExpressions`, if provided and False, disable output f-string 
+expressions. F-string will behave as normal string.
+
+```pycon
+>>> from icecream import ic
+>>> ic.configureOutput(includeFStringExpressions=False)
+>>>
+>>> ss = "Hello World!"
+>>> ic(f"{ss}")
+ic| 'Hello World!'
+
+>>> ic.configureOutput(includeFStringExpressions=True)
+>>>
+>>> ss = "Hello World!"
+>>> ic(f"{ss}")
+ic| f"{ss}": 'Hello World!'
+```
+
+`includeContext` is True by default, for compatibility consideration.
 
 ### Installation
 

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -61,11 +61,13 @@ def disableColoring():
 
 @contextmanager
 def configureIcecreamOutput(prefix=None, outputFunction=None,
-                            argToStringFunction=None, includeContext=None):
+                            argToStringFunction=None, includeContext=None,
+                            includeFStringExpressions=None):
     oldPrefix = ic.prefix
     oldOutputFunction = ic.outputFunction
     oldArgToStringFunction = ic.argToStringFunction
     oldIncludeContext = ic.includeContext
+    oldIncludeFStringExpressions = ic.includeFStringExpressions
 
     if prefix:
         ic.configureOutput(prefix=prefix)
@@ -75,6 +77,8 @@ def configureIcecreamOutput(prefix=None, outputFunction=None,
         ic.configureOutput(argToStringFunction=argToStringFunction)
     if includeContext:
         ic.configureOutput(includeContext=includeContext)
+    if includeFStringExpressions:
+        ic.configureOutput(includeFStringExpressions=includeFStringExpressions)
 
     yield
 


### PR DESCRIPTION
I found the output of `ic(f"var: {var}")` is quite annoying, so I made some changes.

> Add includeFStringExpressions options to ic to control whether print
>   fstring expressions.
> Change README.md for includeFStringExpressions

f-string: [PEP-498](https://www.python.org/dev/peps/pep-0498/)

For python below 3.6, the f-string expression will not pass the syntax check, so I didn't add any python version checks in function `isFString(s)`.

Also, I'm not quite sure about how to implement unit tests in icecream repo. Please add tests if necessary.