### PR TITLE
Include Bash version of ic

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Delicious IceCream should be enjoyed in every language.
 - R: [icecream](https://github.com/lewinfox/icecream)
 - Lua: [icecream-lua](https://github.com/wlingze/icecream-lua)
 - Clojure(Script): [icecream-cljc](https://github.com/Eigenbahn/icecream-cljc)
+- Bash: [IceCream-Bash](https://github.com/jtplaarj/IceCream-Bash)
 
 If you'd like a similar `ic()` function in your favorite language, please open a
 pull request! IceCream's goal is to sweeten print debugging with a handy-dandy


### PR DESCRIPTION
I have created a Bash version of IceCream. If you think it may be useful, consider adding it to your README.