### PR TITLE
singledispatch argumentToString

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ custom fashion.
 ic| 7: 7, 'hello': [!string 'hello' with length 5!]
 ```
 
-The default `argToStringFunction` is `icecream.argumentToString`, and has methods to `register` and `unregister` functions to be dispatched for specific classes (i.e., `singledispatch`). It also has a `registry` property to view registered functions.
+The default `argToStringFunction` is `icecream.argumentToString`, and has methods to `register` and `unregister` functions to be dispatched for specific classes using `functools.singledispatch`. It also has a `registry` property to view registered functions.
 
 ```pycon
 >>> from icecream import ic, argumentToString

--- a/README.md
+++ b/README.md
@@ -292,6 +292,32 @@ custom fashion.
 ic| 7: 7, 'hello': [!string 'hello' with length 5!]
 ```
 
+The default `argToStringFunction` is `icecream.argumentToString`, and has methods to `register` and `unregister` functions to be dispatched for specific classes (i.e., `singledispatch`). It also has a `registry` property to view registered functions.
+
+```pycon
+>>> from icecream import ic, argumentToString
+>>> import numpy as np
+>>>
+>>> # Register a function to summarize numpy array
+>>> @argumentToString.register(np.ndarray)
+>>> def _(obj):
+>>>     return f"ndarray, shape={obj.shape}, dtype={obj.dtype}"
+>>>
+>>> x = np.zeros((1, 2))
+>>> ic(x)
+ic| x: ndarray, shape=(1, 2), dtype=float64
+>>>
+>>> # View registered functions
+>>> argumentToString.registry
+mappingproxy({object: <function icecream.icecream.argumentToString(obj)>,
+              numpy.ndarray: <function __main__._(obj)>})
+>>>
+>>> # Unregister a function and fallback to the default behavior
+>>> argumentToString.unregister(np.ndarray)
+>>> ic(x)
+ic| x: array([[0., 0.]])
+```
+
 `includeContext`, if provided and True, adds the `ic()` call's filename, line
 number, and parent function to `ic()`'s output.
 

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -156,7 +156,6 @@ def format_pair(prefix, arg, value):
 
 
 def singledispatch(func):
-    # build a dictionary mapping names to closure cells
     if "singledispatch" not in dir(functools):
         def unsupport_py2(*args, **kwargs):
             raise NotImplementedError(

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -18,6 +18,7 @@ import inspect
 import pprint
 import sys
 from datetime import datetime
+from functools import singledispatch
 from contextlib import contextmanager
 from os.path import basename
 from textwrap import dedent
@@ -154,6 +155,7 @@ def format_pair(prefix, arg, value):
     return '\n'.join(lines)
 
 
+@singledispatch
 def argumentToString(obj):
     s = DEFAULT_ARG_TO_STRING_FUNCTION(obj)
     s = s.replace('\\n', '\n')  # Preserve string newlines in output.

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -157,7 +157,7 @@ def format_pair(prefix, arg, value):
 
 def singledispatch(func):
     # build a dictionary mapping names to closure cells
-    if "singledispatch" not in functools.__dir__():
+    if "singledispatch" not in dir(functools):
         def unsupport_py2(*args, **kwargs):
             raise NotImplementedError(
                 "functools.singledispatch is missing in " + sys.version

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -169,7 +169,7 @@ def singledispatch(func):
 
     # add unregister based on https://stackoverflow.com/a/25951784
     closure = dict(zip(func.register.__code__.co_freevars, 
-                    func.register.__closure__))
+                       func.register.__closure__))
     registry = closure['registry'].cell_contents
     dispatch_cache = closure['dispatch_cache'].cell_contents
     def unregister(cls):

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -370,14 +370,10 @@ class TestIceCream(unittest.TestCase):
         # Unsupport Python2
         if "singledispatch" not in dir(functools):
             for attr in ("register", "unregister"):
-                try:
+                with self.assertRaises(NotImplementedError):
                     getattr(argumentToString, attr)(
                         tuple, argumentToString_tuple
                     )
-                except NotImplementedError as e:
-                    assert True
-                else:
-                    assert False
             return
 
         # Prepare input and output

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -367,7 +367,7 @@ class TestIceCream(unittest.TestCase):
 
     def testSingledispatchArgumentToString(self):
         # Unsupport Python2
-        if "singledispatch" not in functools.__dir__():
+        if "singledispatch" not in dir(functools):
             assert isinstance(
                 argumentToString.register(tuple, argumentToString_tuple),
                 NotImplementedError

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -13,8 +13,6 @@
 import functools
 import sys
 import unittest
-
-from numpy import kaiser
 try:  # Python 2.x.
     from StringIO import StringIO
 except ImportError:  # Python 3.x.
@@ -366,16 +364,20 @@ class TestIceCream(unittest.TestCase):
         assert pair == ('eins', 'zwei')
 
     def testSingledispatchArgumentToString(self):
+        def argumentToString_tuple(obj):
+            return "Dispatching tuple!"
+
         # Unsupport Python2
         if "singledispatch" not in dir(functools):
-            assert isinstance(
-                argumentToString.register(tuple, argumentToString_tuple),
-                NotImplementedError
-            )
-            assert isinstance(
-                argumentToString.unregister(tuple),
-                NotImplementedError
-            )
+            for attr in ("register", "unregister"):
+                try:
+                    getattr(argumentToString, attr)(
+                        tuple, argumentToString_tuple
+                    )
+                except NotImplementedError as e:
+                    assert True
+                else:
+                    assert False
             return
 
         # Prepare input and output
@@ -383,10 +385,7 @@ class TestIceCream(unittest.TestCase):
         default_output = ic.format(x)
 
         # Register
-        @argumentToString.register(tuple)
-        def argumentToString_tuple(obj):
-            return "Dispatching tuple!"
-
+        argumentToString.register(tuple, argumentToString_tuple)
         assert tuple in argumentToString.registry
         assert str.endswith(ic.format(x), argumentToString_tuple(x))
 


### PR DESCRIPTION
Current implementation requires users to rewrite `argToStringFunction` totally.

I would suggest singledispatch `argumentToString`, which allows sort of ad-hoc way to stringify the argument.

This makes codes shorter.
Also, This is very handy especially on Jupyter Notebook because users may add customizations in working cells, instead of going back to the cell which defines custom `argToStringFunction` in a current manner.

``` python
from icecream import ic, argumentToString
import numpy as np

@argumentToString.register(np.ndarray)
def argumentToString_ndarray(obj):
    return f"shape: {obj.shape}, min: {obj.min()}, mean: {obj.mean()}, max: {obj.max()}"

x = np.arange(10).reshape(5, -1)
ic(x)
```

```
ic| x: shape: (5, 2), min: 0, mean: 4.5, max: 9
array([[0, 1],
       [2, 3],
       [4, 5],
       [6, 7],
       [8, 9]])
```
