### PR TITLE
Add Feature: Printing Absolute Path in Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,25 @@ ic| example.py:12 in foo()- 'str': 'str'
 
 `includeContext` is False by default.
 
+`absPath`, False by default, can be used to control whether `ic()`'s output includes the absolute path of the file where `ic()` is called, provided `includeContext == True`. This is useful when `ic()` is called from multiple files in a project, with files having same names but different paths. Moreover, for most editors such as VSCode, a clickable link to the line where `ic()` is called is provided:
+
+```pycon
+>>> from icecream import ic
+>>> ic.configureOutput(includeContext=True, absPath=True)
+>>>
+>>> def foo():
+>>>   ic('str')
+>>> foo()
+ic| /absolute/path/to/example.py:12 in foo()- 'str': 'str'
+>>> ic.configureOutput(includeContext=True, absPath=False)
+>>>
+>>> def foo():
+>>>   ic('str')
+>>> foo()
+ic| example.py:12 in foo()- 'str': 'str'
+```
+
+Here, a click on `/absolute/path/to/example.py:12` brings you to the line of the debugging call. It is really handy when you have debugging outputs from multiple files and want to easily jump to the line where the debugging call is made.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -333,17 +333,17 @@ ic| example.py:12 in foo()- 'str': 'str'
 
 `includeContext` is False by default.
 
-`absPath`, False by default, can be used to control whether `ic()`'s output includes the absolute path of the file where `ic()` is called, provided `includeContext == True`. This is useful when `ic()` is called from multiple files in a project, with files having same names but different paths. Moreover, for most editors such as VSCode, a clickable link to the line where `ic()` is called is provided:
+`contextAbsPath`, False by default, can be used to control whether `ic()`'s output includes the absolute path of the file where `ic()` is called, provided `includeContext == True`. This is useful when `ic()` is called from multiple files in a project, with files having same names but different paths. Moreover, for most editors such as VSCode, a clickable link to the line where `ic()` is called is provided:
 
 ```pycon
 >>> from icecream import ic
->>> ic.configureOutput(includeContext=True, absPath=True)
+>>> ic.configureOutput(includeContext=True, contextAbsPath=True)
 >>>
 >>> def foo():
 >>>   ic('str')
 >>> foo()
 ic| /absolute/path/to/example.py:12 in foo()- 'str': 'str'
->>> ic.configureOutput(includeContext=True, absPath=False)
+>>> ic.configureOutput(includeContext=True, contextAbsPath=False)
 >>>
 >>> def foo():
 >>>   ic('str')

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -20,7 +20,7 @@ import sys
 from datetime import datetime
 import functools
 from contextlib import contextmanager
-from os.path import basename
+from os.path import basename, realpath
 from textwrap import dedent
 
 import colorama
@@ -32,7 +32,7 @@ from pygments import highlight
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import PythonLexer as PyLexer, Python3Lexer as Py3Lexer
 
-from .coloring import SolarizedDark
+from coloring import SolarizedDark
 
 
 PYTHON2 = (sys.version_info[0] == 2)
@@ -192,12 +192,14 @@ class IceCreamDebugger:
 
     def __init__(self, prefix=DEFAULT_PREFIX,
                  outputFunction=DEFAULT_OUTPUT_FUNCTION,
-                 argToStringFunction=argumentToString, includeContext=False):
+                 argToStringFunction=argumentToString, includeContext=False,
+                 absPath=False):
         self.enabled = True
         self.prefix = prefix
         self.includeContext = includeContext
         self.outputFunction = outputFunction
         self.argToStringFunction = argToStringFunction
+        self.absPath = absPath
 
     def __call__(self, *args):
         if self.enabled:
@@ -330,9 +332,13 @@ class IceCreamDebugger:
         lineNumber = callNode.lineno
         frameInfo = inspect.getframeinfo(callFrame)
         parentFunction = frameInfo.function
-        filename = basename(frameInfo.filename)
 
-        return filename, lineNumber, parentFunction
+        if self.absPath:
+            filepath = realpath(frameInfo.filename)
+            return filepath, lineNumber, parentFunction
+        else:
+            filename = basename(frameInfo.filename)
+            return filename, lineNumber, parentFunction
 
     def enable(self):
         self.enabled = True
@@ -341,7 +347,8 @@ class IceCreamDebugger:
         self.enabled = False
 
     def configureOutput(self, prefix=_absent, outputFunction=_absent,
-                        argToStringFunction=_absent, includeContext=_absent):
+                        argToStringFunction=_absent, includeContext=_absent,
+                        absPath=_absent):
         if prefix is not _absent:
             self.prefix = prefix
 
@@ -353,6 +360,9 @@ class IceCreamDebugger:
 
         if includeContext is not _absent:
             self.includeContext = includeContext
+        
+        if absPath is not _absent:
+            self.absPath = absPath
 
 
 ic = IceCreamDebugger()

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -193,13 +193,13 @@ class IceCreamDebugger:
     def __init__(self, prefix=DEFAULT_PREFIX,
                  outputFunction=DEFAULT_OUTPUT_FUNCTION,
                  argToStringFunction=argumentToString, includeContext=False,
-                 absPath=False):
+                 contextAbsPath=False):
         self.enabled = True
         self.prefix = prefix
         self.includeContext = includeContext
         self.outputFunction = outputFunction
         self.argToStringFunction = argToStringFunction
-        self.absPath = absPath
+        self.contextAbsPath = contextAbsPath
 
     def __call__(self, *args):
         if self.enabled:
@@ -333,7 +333,7 @@ class IceCreamDebugger:
         frameInfo = inspect.getframeinfo(callFrame)
         parentFunction = frameInfo.function
 
-        filepath = (realpath if self.absPath else basename)(frameInfo.filename)
+        filepath = (realpath if self.contextAbsPath else basename)(frameInfo.filename)
         return filepath, lineNumber, parentFunction
 
     def enable(self):
@@ -344,7 +344,7 @@ class IceCreamDebugger:
 
     def configureOutput(self, prefix=_absent, outputFunction=_absent,
                         argToStringFunction=_absent, includeContext=_absent,
-                        absPath=_absent):
+                        contextAbsPath=_absent):
         if prefix is not _absent:
             self.prefix = prefix
 
@@ -357,8 +357,8 @@ class IceCreamDebugger:
         if includeContext is not _absent:
             self.includeContext = includeContext
         
-        if absPath is not _absent:
-            self.absPath = absPath
+        if contextAbsPath is not _absent:
+            self.contextAbsPath = contextAbsPath
 
 
 ic = IceCreamDebugger()

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -32,7 +32,7 @@ from pygments import highlight
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import PythonLexer as PyLexer, Python3Lexer as Py3Lexer
 
-from coloring import SolarizedDark
+from .coloring import SolarizedDark
 
 
 PYTHON2 = (sys.version_info[0] == 2)

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -333,12 +333,8 @@ class IceCreamDebugger:
         frameInfo = inspect.getframeinfo(callFrame)
         parentFunction = frameInfo.function
 
-        if self.absPath:
-            filepath = realpath(frameInfo.filename)
-            return filepath, lineNumber, parentFunction
-        else:
-            filename = basename(frameInfo.filename)
-            return filename, lineNumber, parentFunction
+        filepath = (realpath if self.absPath else basename)(frameInfo.filename)
+        return filepath, lineNumber, parentFunction
 
     def enable(self):
         self.enabled = True

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -18,7 +18,7 @@ try:  # Python 2.x.
 except ImportError:  # Python 3.x.
     from io import StringIO
 from contextlib import contextmanager
-from os.path import basename, splitext
+from os.path import basename, splitext, realpath
 
 import icecream
 from icecream import ic, argumentToString, stderrPrint, NoSourceAvailableError
@@ -26,6 +26,7 @@ from icecream import ic, argumentToString, stderrPrint, NoSourceAvailableError
 
 TEST_PAIR_DELIMITER = '| '
 MYFILENAME = basename(__file__)
+MYFILEPATH = realpath(__file__)
 
 
 a = 1
@@ -62,11 +63,13 @@ def disableColoring():
 
 @contextmanager
 def configureIcecreamOutput(prefix=None, outputFunction=None,
-                            argToStringFunction=None, includeContext=None):
+                            argToStringFunction=None, includeContext=None,
+                            contextAbsPath=None):
     oldPrefix = ic.prefix
     oldOutputFunction = ic.outputFunction
     oldArgToStringFunction = ic.argToStringFunction
     oldIncludeContext = ic.includeContext
+    oldContextAbsPath = ic.contextAbsPath
 
     if prefix:
         ic.configureOutput(prefix=prefix)
@@ -76,12 +79,14 @@ def configureIcecreamOutput(prefix=None, outputFunction=None,
         ic.configureOutput(argToStringFunction=argToStringFunction)
     if includeContext:
         ic.configureOutput(includeContext=includeContext)
+    if contextAbsPath:
+        ic.configureOutput(contextAbsPath=contextAbsPath)
 
     yield
 
     ic.configureOutput(
         oldPrefix, oldOutputFunction, oldArgToStringFunction,
-        oldIncludeContext)
+        oldIncludeContext, oldContextAbsPath)
 
 
 @contextmanager
@@ -127,6 +132,17 @@ def lineIsContext(line):
         name == splitext(MYFILENAME)[0] and
         (function == '<module>' or function.endswith('()')))
 
+def lineIsAbsPathContext(line):
+    line = stripPrefix(line)  # ic| /absolute/path/to/f.py:33 in foo()
+    sourceLocation, function = line.split(' in ')  # /absolute/path/to/f.py:33 in foo()
+    filepath, lineNumber = sourceLocation.split(':')  # /absolute/path/to/f.py:33
+    path, ext = splitext(filepath)
+
+    return (
+        int(lineNumber) > 0 and
+        ext in ['.py', '.pyc', '.pyo'] and
+        path == splitext(MYFILEPATH)[0] and
+        (function == '<module>' or function.endswith('()')))
 
 def lineAfterContext(line, prefix):
     if line.startswith(prefix):
@@ -446,6 +462,15 @@ class TestIceCream(unittest.TestCase):
         pair = parseOutputIntoPairs(out, err, 1)[0][0]
         assert pair == ('i', '3')
 
+    def testContextAbsPathSingleLine(self):
+        i = 3
+        with configureIcecreamOutput(includeContext=True, contextAbsPath=True):
+            with disableColoring(), captureStandardStreams() as (out, err):
+                ic(i)
+        # Output with absolute path can easily exceed line width, so no assert line num here.
+        pairs = parseOutputIntoPairs(out, err, 0)
+        assert [('i', '3')] in pairs
+
     def testValues(self):
         with disableColoring(), captureStandardStreams() as (out, err):
             # Test both 'asdf' and "asdf"; see
@@ -467,6 +492,18 @@ class TestIceCream(unittest.TestCase):
         pair = parseOutputIntoPairs(out, err, 3)[1][0]
         assert pair == ('multilineStr', ic.argToStringFunction(multilineStr))
 
+    def testContextAbsPathMultiLine(self):
+        multilineStr = 'line1\nline2'
+        with configureIcecreamOutput(includeContext=True, contextAbsPath=True):
+            with disableColoring(), captureStandardStreams() as (out, err):
+                ic(multilineStr)
+
+        firstLine = err.getvalue().splitlines()[0]
+        assert lineIsAbsPathContext(firstLine) # TODO
+
+        pair = parseOutputIntoPairs(out, err, 3)[1][0]
+        assert pair == ('multilineStr', ic.argToStringFunction(multilineStr))
+    
     def testFormat(self):
         with disableColoring(), captureStandardStreams() as (out, err):
             """comment"""; noop(); ic(  # noqa


### PR DESCRIPTION
`ic.configureOutput(includeContext=True, absPath=True)`

`absPath`, False by default, can be used to control whether `ic()`'s output includes the absolute path of the file where `ic()` is called, provided `includeContext == True`. This is useful when `ic()` is called from multiple files in a project, with files potentially having same names but different paths. Moreover, for most editors such as VSCode, a clickable link to the line where `ic()` is called is provided. E.g. a click on `/absolute/path/to/example.py:12` brings you to the line of the debugging call. It is really handy when you have debugging outputs from multiple files and want to easily jump to the line where the debugging call is made.