### PR TITLE
We want to still print the given args even when the source is unavaii…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -144,8 +144,12 @@ def indented_lines(prefix, string):
 
 
 def format_pair(prefix, arg, value):
-    arg_lines = indented_lines(prefix, arg)
-    value_prefix = arg_lines[-1] + ': '
+    if arg is _arg_source_missing:
+        arg_lines = []
+        value_prefix = prefix
+    else:
+        arg_lines = indented_lines(prefix, arg)
+        value_prefix = arg_lines[-1] + ': '
 
     looksLikeAString = value[0] + value[-1] in ["''", '""']
     if looksLikeAString:  # Align the start of multiline strings.

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -245,7 +245,7 @@ class IceCreamDebugger:
                 for arg in callNode.args]
         else:
             warnings.warn(NO_SOURCE_AVAILABLE_WARNING_MESSAGE,
-                          category=RuntimeWarning)
+                          category=RuntimeWarning, stacklevel=4)
             sanitizedArgStrs = [_arg_source_missing] * len(args)
 
         pairs = list(zip(sanitizedArgStrs, args))

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -104,7 +104,7 @@ This can happen, for example, when
   - The underlying source code changed during execution. See
     https://stackoverflow.com/a/33175832.
 """
-NO_SOURCE_AVAILABLE_INFO_MESSAGE = (
+DEFAULT_NO_SOURCE_AVAILABLE_MESSAGE = (
     'Error: Failed to access the underlying source code for analysis. Was ic() '
     'invoked in a REPL (e.g. from the command line), a frozen application '
     '(e.g. packaged with PyInstaller), or did the underlying source code '
@@ -193,13 +193,15 @@ class IceCreamDebugger:
     def __init__(self, prefix=DEFAULT_PREFIX,
                  outputFunction=DEFAULT_OUTPUT_FUNCTION,
                  argToStringFunction=argumentToString, includeContext=False,
-                 contextAbsPath=False):
+                 contextAbsPath=False,
+                 noSourceAvailableMessage=DEFAULT_NO_SOURCE_AVAILABLE_MESSAGE):
         self.enabled = True
         self.prefix = prefix
         self.includeContext = includeContext
         self.outputFunction = outputFunction
         self.argToStringFunction = argToStringFunction
         self.contextAbsPath = contextAbsPath
+        self.noSourceAvailableMessage = noSourceAvailableMessage
 
     def __call__(self, *args):
         if self.enabled:
@@ -243,7 +245,7 @@ class IceCreamDebugger:
                 source.get_text_with_indentation(arg)
                 for arg in callNode.args]
         else:
-            sanitizedArgStrs = [NO_SOURCE_AVAILABLE_INFO_MESSAGE] * len(args)
+            sanitizedArgStrs = [self.noSourceAvailableMessage] * len(args)
 
         pairs = list(zip(sanitizedArgStrs, args))
 
@@ -338,7 +340,8 @@ class IceCreamDebugger:
 
     def configureOutput(self, prefix=_absent, outputFunction=_absent,
                         argToStringFunction=_absent, includeContext=_absent,
-                        contextAbsPath=_absent):
+                        contextAbsPath=_absent,
+                        noSourceAvailableMessage=_absent):
         noParameterProvided = all(
             v is _absent for k,v in locals().items() if k != 'self')
         if noParameterProvided:
@@ -358,6 +361,9 @@ class IceCreamDebugger:
         
         if contextAbsPath is not _absent:
             self.contextAbsPath = contextAbsPath
+
+        if noSourceAvailableMessage is not _absent:
+            self.noSourceAvailableMessage = noSourceAvailableMessage
 
 
 ic = IceCreamDebugger()

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -104,7 +104,7 @@ This can happen, for example, when
   - The underlying source code changed during execution. See
     https://stackoverflow.com/a/33175832.
 """
-DEFAULT_NO_SOURCE_AVAILABLE_MESSAGE = (
+NO_SOURCE_AVAILABLE_INFO_MESSAGE = (
     'Error: Failed to access the underlying source code for analysis. Was ic() '
     'invoked in a REPL (e.g. from the command line), a frozen application '
     '(e.g. packaged with PyInstaller), or did the underlying source code '
@@ -193,15 +193,13 @@ class IceCreamDebugger:
     def __init__(self, prefix=DEFAULT_PREFIX,
                  outputFunction=DEFAULT_OUTPUT_FUNCTION,
                  argToStringFunction=argumentToString, includeContext=False,
-                 contextAbsPath=False,
-                 noSourceAvailableMessage=DEFAULT_NO_SOURCE_AVAILABLE_MESSAGE):
+                 contextAbsPath=False):
         self.enabled = True
         self.prefix = prefix
         self.includeContext = includeContext
         self.outputFunction = outputFunction
         self.argToStringFunction = argToStringFunction
         self.contextAbsPath = contextAbsPath
-        self.noSourceAvailableMessage = noSourceAvailableMessage
 
     def __call__(self, *args):
         if self.enabled:
@@ -245,7 +243,7 @@ class IceCreamDebugger:
                 source.get_text_with_indentation(arg)
                 for arg in callNode.args]
         else:
-            sanitizedArgStrs = [self.noSourceAvailableMessage] * len(args)
+            sanitizedArgStrs = [NO_SOURCE_AVAILABLE_INFO_MESSAGE] * len(args)
 
         pairs = list(zip(sanitizedArgStrs, args))
 
@@ -340,8 +338,7 @@ class IceCreamDebugger:
 
     def configureOutput(self, prefix=_absent, outputFunction=_absent,
                         argToStringFunction=_absent, includeContext=_absent,
-                        contextAbsPath=_absent,
-                        noSourceAvailableMessage=_absent):
+                        contextAbsPath=_absent):
         noParameterProvided = all(
             v is _absent for k,v in locals().items() if k != 'self')
         if noParameterProvided:
@@ -361,9 +358,6 @@ class IceCreamDebugger:
         
         if contextAbsPath is not _absent:
             self.contextAbsPath = contextAbsPath
-
-        if noSourceAvailableMessage is not _absent:
-            self.noSourceAvailableMessage = noSourceAvailableMessage
 
 
 ic = IceCreamDebugger()

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from os.path import basename, splitext, realpath
 
 import icecream
-from icecream import ic, argumentToString, stderrPrint, DEFAULT_NO_SOURCE_AVAILABLE_MESSAGE
+from icecream import ic, argumentToString, stderrPrint, NO_SOURCE_AVAILABLE_INFO_MESSAGE
 
 TEST_PAIR_DELIMITER = '| '
 MY_FILENAME = basename(__file__)
@@ -63,14 +63,12 @@ def disableColoring():
 @contextmanager
 def configureIcecreamOutput(prefix=None, outputFunction=None,
                             argToStringFunction=None, includeContext=None,
-                            contextAbsPath=None,
-                            noSourceAvailableMessage=None):
+                            contextAbsPath=None):
     oldPrefix = ic.prefix
     oldOutputFunction = ic.outputFunction
     oldArgToStringFunction = ic.argToStringFunction
     oldIncludeContext = ic.includeContext
     oldContextAbsPath = ic.contextAbsPath
-    oldNoSourceAvailableMessage = ic.noSourceAvailableMessage
 
     if prefix:
         ic.configureOutput(prefix=prefix)
@@ -82,14 +80,12 @@ def configureIcecreamOutput(prefix=None, outputFunction=None,
         ic.configureOutput(includeContext=includeContext)
     if contextAbsPath:
         ic.configureOutput(contextAbsPath=contextAbsPath)
-    if noSourceAvailableMessage:
-        ic.configureOutput(noSourceAvailableMessage=noSourceAvailableMessage)
 
     yield
 
     ic.configureOutput(
         oldPrefix, oldOutputFunction, oldArgToStringFunction,
-        oldIncludeContext, oldContextAbsPath, oldNoSourceAvailableMessage)
+        oldIncludeContext, oldContextAbsPath)
 
 
 @contextmanager
@@ -537,17 +533,7 @@ class TestIceCream(unittest.TestCase):
         self.assertEqual(err.getvalue().strip(), """
 ic| {0}: 1
     {0}: 2
-        """.format(DEFAULT_NO_SOURCE_AVAILABLE_MESSAGE).strip())
-
-    def testNoSourceAvailableConfiguration(self):
-        noSourceAvailableMessage = 'no source'
-        with configureIcecreamOutput(noSourceAvailableMessage=noSourceAvailableMessage):
-            with disableColoring(), captureStandardStreams() as (out, err):
-                eval('ic(a)')
-
-            self.assertEqual(err.getvalue().strip(), """
-    ic| {0}: 1
-            """.format(noSourceAvailableMessage).strip())
+        """.format(NO_SOURCE_AVAILABLE_INFO_MESSAGE).strip())
 
     def testSingleTupleArgument(self):
         with disableColoring(), captureStandardStreams() as (out, err):

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -21,8 +21,7 @@ from contextlib import contextmanager
 from os.path import basename, splitext, realpath
 
 import icecream
-from icecream import ic, argumentToString, stderrPrint, NoSourceAvailableError
-
+from icecream import ic, argumentToString, stderrPrint, NO_SOURCE_AVAILABLE_INFO_MESSAGE
 
 TEST_PAIR_DELIMITER = '| '
 MY_FILENAME = basename(__file__)
@@ -529,8 +528,12 @@ class TestIceCream(unittest.TestCase):
 
     def testNoSourceAvailable(self):
         with disableColoring(), captureStandardStreams() as (out, err):
-            eval('ic()')
-        assert NoSourceAvailableError.infoMessage in err.getvalue()
+            eval('ic(a, b)')
+
+        self.assertEqual(err.getvalue().strip(), """
+ic| {0}: 1
+    {0}: 2
+        """.format(NO_SOURCE_AVAILABLE_INFO_MESSAGE).strip())
 
     def testSingleTupleArgument(self):
         with disableColoring(), captureStandardStreams() as (out, err):


### PR DESCRIPTION
A common usage scenario of icecream is debugging long running processes.
As part of the debug process a common scenario is that the underlying source code is updated with new insights.
The current behavior causes all the scheduled prints using `ic()` to fail and only show the following message:
```
ic| Error: Failed to access the underlying source code for analysis. Was ic() invoked in a REPL (e.g. from the command line), a frozen application (e.g. packaged with PyInstaller), or did the underlying source code change during execution?
```

This fix understands that the user probably still wants to see their printed debug values even if icecream can't introspect the arguments themselves.
After this PR is merged if we run:
```python
from icecream import ic
from time import sleep
a, b = 1, 2
sleep(10)
ic(a, b)
```
And change the underlying source code during the sleep period, ic will still print the values:
```
ic| Error: Failed to access the underlying source code for analysis. Was ic() invoked in a REPL (e.g. from the command line), a frozen application (e.g. packaged with PyInstaller), or did the underlying source code change during execution?: 1
    Error: Failed to access the underlying source code for analysis. Was ic() invoked in a REPL (e.g. from the command line), a frozen application (e.g. packaged with PyInstaller), or did the underlying source code change during execution?: 2
```

Since the default error message is really long and informative we want to allow users to configure the error message so that on the common scenario of a known source change when a user prints a value they can configure a short message that looks something like:
```python
from icecream import ic
ic.configureOutput(noSourceAvailableMessage='Source file changed')
a = 1
eval('ic(a)')

# ic| Source file changed: 1
```