### PR TITLE
Exposing functions to toggle between stdour and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,20 @@ of written to stderr.
 ic| s: 'sup'
 ```
 
+To enable strings to be written to either `stdout` or `stderr`, we can use 
+`ic.enableStdout()` or `ic.enableStderr()` toggles between the two.
+to
+
+```python
+from icecream import ic
+ic("Hello World!") # by default it prints to to stderr
+ic.enableStdout()
+ic("This is printed to stdout") # prints string to stdout
+
+ic.enableStderr()
+ic("This is printed to stderr") # prints string to stderr
+```
+
 Additionally, `ic()`'s output can be entirely disabled, and later re-enabled, with
 `ic.disable()` and `ic.enable()` respectively.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ ic| s: 'sup'
 
 To enable strings to be written to either `stdout` or `stderr`, we can use 
 `ic.enableStdout()` or `ic.enableStderr()` toggles between the two.
-to
 
 ```python
 from icecream import ic

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -70,6 +70,10 @@ def stderrPrint(*args):
     print(*args, file=sys.stderr)
 
 
+def stdoutPrint(*args):
+    print(*args)
+
+
 def isLiteral(s):
     try:
         ast.literal_eval(s)
@@ -82,6 +86,12 @@ def colorizedStderrPrint(s):
     colored = colorize(s)
     with supportTerminalColorsInWindows():
         stderrPrint(colored)
+
+
+def colorizedStdoutPrint(s):
+    colored = colorize(s)
+    with supportTerminalColorsInWindows():
+        stdoutPrint(colored)
 
 
 DEFAULT_PREFIX = 'ic| '
@@ -369,6 +379,12 @@ class IceCreamDebugger:
         
         if contextAbsPath is not _absent:
             self.contextAbsPath = contextAbsPath
+
+    def enableStdout(self):
+        self.outputFunction = colorizedStdoutPrint
+
+    def enableStderr(self):
+        self.outputFunction = colorizedStderrPrint
 
 
 ic = IceCreamDebugger()


### PR DESCRIPTION
This PR adds the functionality to toggle between which print function to use.

Following the function `colorizedStderrPrint` I have added a similar one for `colorizedStdoutPrint` that prints to stdout

Additionally I have added 2 new methods:
* `enableStdout`
* `enableStderr`
 That toggles between which print function to use:
```python
ic.enableStdout()  # sets `colorizedStdoutPrint`
ic.enableStderr()  # sets `colorizedStderrPrint`
```

default functionality unchanged,  when import `ic` it still defaults to stderr function


I have also updated the documentation under misc section how to use the feature