### PR TITLE
Multi-Configuration/Multi-Installation to Built-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ or a function.
 ```pycon
 >>> import time
 >>> from icecream import ic
->>>  
+>>>
 >>> def unixTimestamp():
 >>>     return '%i |> ' % int(time.time())
 >>>
@@ -367,6 +367,32 @@ ic| example.py:18 in foo()- i: 3
 ```
 
 `contextAbsPath` is False by default.
+
+#### Multi-Configuration
+You might want to create multiple configurations bound to different names.
+For example, `ic()` with context for usual output in terminal,
+and `ik()` without context for piping to logger which usually has context already.
+The `ik` name is just an example (e.g. short for `ice-kream`).
+
+```python
+from icecream import IceCreamDebugger, ic, install
+
+# Usual instance, for reference.
+ic.configureOutput(includeContext=True)
+install()
+
+# Second instance/configuration.
+ik = IceCreamDebugger()
+ik.configureOutput(includeContext=False, prefix='')
+install(attribute='ik', value=ik)
+
+# Pipe IceCream output to a logger.
+# Logger usually has context already, so the IceCream's context is redundant.
+# So, we could just redirect the IceCream contents without context.
+# Likewise, this makes it possible to control IceCream with log level.
+foo = 'bar'
+logger.debug(ik.format(foo))
+```
 
 ### Installation
 

--- a/icecream/builtins.py
+++ b/icecream/builtins.py
@@ -19,9 +19,9 @@ except ImportError:
     builtins = __import__('builtins')
 
 
-def install(ic='ic'):
-    setattr(builtins, ic, icecream.ic)
+def install(attribute='ic', value=icecream.ic):
+    setattr(builtins, attribute, value)
 
 
-def uninstall(ic='ic'):
-    delattr(builtins, ic)
+def uninstall(attribute='ic'):
+    delattr(builtins, attribute)

--- a/tests/install_test_import.py
+++ b/tests/install_test_import.py
@@ -10,6 +10,11 @@
 # License: MIT
 #
 
-def runMe():
+def runMeDefault():
     x = 3
     ic(x)
+
+
+def runMeCustom():
+    x = 4
+    ik(x)

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -54,12 +54,12 @@ class FakeTeletypeBuffer(StringIO):
 
 
 @contextmanager
-def disableColoring():
-    originalOutputFunction = ic.outputFunction
+def disableColoring(icecream_instance=ic):
+    originalOutputFunction = icecream_instance.outputFunction
 
-    ic.configureOutput(outputFunction=stderrPrint)
+    icecream_instance.configureOutput(outputFunction=stderrPrint)
     yield
-    ic.configureOutput(outputFunction=originalOutputFunction)
+    icecream_instance.configureOutput(outputFunction=originalOutputFunction)
 
 
 @contextmanager
@@ -505,7 +505,7 @@ class TestIceCream(unittest.TestCase):
 
         pair = parseOutputIntoPairs(out, err, 3)[1][0]
         assert pair == ('multilineStr', ic.argToStringFunction(multilineStr))
-    
+
     def testFormat(self):
         with disableColoring(), captureStandardStreams() as (out, err):
             """comment"""; noop(); ic(  # noqa

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,21 +13,28 @@
 import unittest
 
 import icecream
+from install_test_import import (
+    runMeCustom,
+    runMeDefault,
+)
 from test_icecream import (
-    disableColoring, captureStandardStreams, parseOutputIntoPairs)
-
-from install_test_import import runMe
+    captureStandardStreams,
+    disableColoring,
+    parseOutputIntoPairs,
+)
 
 
 class TestIceCreamInstall(unittest.TestCase):
-    def testInstall(self):
+
+    def testInstallDefault(self):
         icecream.install()
         with disableColoring(), captureStandardStreams() as (out, err):
-            runMe()
+            runMeDefault()
+
         assert parseOutputIntoPairs(out, err, 1)[0][0] == ('x', '3')
         icecream.uninstall()  # Clean up builtins.
 
-    def testUninstall(self):
+    def testUninstallDefault(self):
         try:
             icecream.uninstall()
         except AttributeError:  # Already uninstalled.
@@ -35,4 +42,26 @@ class TestIceCreamInstall(unittest.TestCase):
 
         # NameError: global name 'ic' is not defined.
         with self.assertRaises(NameError):
-            runMe()
+            runMeDefault()
+
+    def testInstallCustom(self):
+        # Create new instance of IceCream and install it.
+        ik = icecream.IceCreamDebugger()
+        ik.configureOutput(includeContext=False, prefix='')
+        icecream.install(attribute='ik', value=ik)
+
+        with disableColoring(icecream_instance=ik), captureStandardStreams() as (out, err):
+            runMeCustom()
+
+        assert parseOutputIntoPairs(out, err, 1)[0][0] == ('x', '4')
+        icecream.uninstall(attribute='ik')  # Clean up builtins.
+
+    def testUninstallCustom(self):
+        try:
+            icecream.uninstall('ik')
+        except AttributeError:  # Already uninstalled.
+            pass
+
+        # NameError: global name 'ik' is not defined.
+        with self.assertRaises(NameError):
+            runMeCustom()


### PR DESCRIPTION
Thanks for this awesome tool! :)

I usually have these use cases when working with our Python/Django projects:
- printing to terminal: `ic()` with context and custom prefix
- piping to logger: `ic()` without context and prefix 

But currently, these 2 cases could not exist at the same time since `configureOutput()` is being applied on the same `ic` object. 

Figured out that an effective solution is to have a way to create multiple instances of `IceCream` wherein each of them could have different configurations and could be added in `builtins` with different names (e.g. `ic()` and `ik()):
- printing to terminal: `ic()` with context and custom prefix
- piping to logger: `ik()` without context and prefix 

Hence, created this PR. I use the code changes here in our projects for some time already and it's working as intended. Likewise, updated the unit tests and README. Cheers!