### PR TITLE
Allow extra arguments to ic call

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -184,8 +184,8 @@ def singledispatch(func):
 
 
 @singledispatch
-def argumentToString(obj):
-    s = DEFAULT_ARG_TO_STRING_FUNCTION(obj)
+def argumentToString(obj, **kwargs):
+    s = DEFAULT_ARG_TO_STRING_FUNCTION(obj, **kwargs)
     s = s.replace('\\n', '\n')  # Preserve string newlines in output.
     return s
 
@@ -206,7 +206,9 @@ class IceCreamDebugger:
         self.argToStringFunction = argToStringFunction
         self.contextAbsPath = contextAbsPath
 
-    def __call__(self, *args):
+    def __call__(self, *args, **kwargs):
+        self.kwargs = kwargs
+
         if self.enabled:
             callFrame = inspect.currentframe().f_back
             self.outputFunction(self._format(callFrame, *args))
@@ -261,7 +263,7 @@ class IceCreamDebugger:
         def argPrefix(arg):
             return '%s: ' % arg
 
-        pairs = [(arg, self.argToStringFunction(val)) for arg, val in pairs]
+        pairs = [(arg, self.argToStringFunction(val, **self.kwargs)) for arg, val in pairs]
         # For cleaner output, if <arg> is a literal, eg 3, "string", b'bytes',
         # etc, only output the value, not the argument and the value, as the
         # argument and the value will be identical or nigh identical. Ex: with


### PR DESCRIPTION
This change allows you to add extra keyworded arguments to your ic function call.
This solves a problem that I faced when I wanted my list prints to be customized, but ic didn't allowed me to change the argToStringFunction's optional arguments. As an example, the default function that works in the background to format the input, pprint.pformat, can accept the optional arguments such as compact, but ic doesn't handle those. 

Code:
```
l = [111111, 222222, 333333, 444444, 555555, 666666, 777777, 888888, 999999, 101010, 111111]

ic(l, compact=True) # this would fails without this commit
ic(l)
```
Output:
```
ic| l: [111111, 222222, 333333, 444444, 555555, 666666, 777777, 888888, 999999, 101010,
        111111]
ic| l: [111111,
        222222,
        333333,
        444444,
        555555,
        666666,
        777777,
        888888,
        999999,
        101010,
        111111]
```
Also, this supports the usage of kwargs in user created argToStringFunction

*I hope you like it, this is my first open source contribution