### PR TITLE
limit `executing` version dep to < 2.0.0 to make icecream under py2 work again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     install_requires=[
         'colorama>=0.3.9',
         'pygments>=2.2.0',
-        'executing>=0.3.1',
+        'executing>=0.3.1,<2.0.0',
         'asttokens>=2.0.1',
     ],
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ setup(
     install_requires=[
         'colorama>=0.3.9',
         'pygments>=2.2.0',
-        'executing>=0.3.1,<2.0.0',
+        'executing>=2.0.0; python_version >= "3.5"',
+        'executing>=0.3.1,<2.0.0; python_version < "3.0"',
         'asttokens>=2.0.1',
     ],
     cmdclass={


### PR DESCRIPTION
The latest version of [`executing`](https://github.com/alexmojaki/executing) ([2.0.0](https://github.com/alexmojaki/executing/releases/tag/v2.0.0)) breaks `icecream` under Python 2, failing with `ImportError: cannot import name lru_cache`. Though it's not called out explicitly, `executing` 2.0.0 drops support for Py2.

This PR limits the `executing` version to `<2.0.0` for Py2, and allows `>=2.0.0` for Py3. (`executing` 2.0.0 supports Python 3.5 to 3.12, inclusive.)

Example of failure:
```
$ git clone git@github.com:gruns/icecream.git

$ cd icecream

$ pyenv local 2.7.18 3.9.16

$ python2 -m virtualenv .venv2
created virtual environment CPython2.7.18.final.0-64 in 383ms
  creator CPython2Posix(dest=/Users/justinb/projects.opensource/icecream/.venv2, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, wheel=bundle, setuptools=bundle, via=copy, app_data_dir=/Users/justinb/Library/Application Support/virtualenv)
    added seed packages: pip==20.3.4, setuptools==44.1.1, wheel==0.37.1
  activators NushellActivator,PythonActivator,FishActivator,CShellActivator,PowerShellActivator,BashActivator

$ source .venv2/bin/activate

(.venv2) 
$ python2 -m pip install -e .
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Obtaining file:///Users/justinb/projects.opensource/icecream
Collecting colorama>=0.3.9
  Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting pygments>=2.2.0
  Using cached Pygments-2.5.2-py2.py3-none-any.whl (896 kB)
Collecting executing>=0.3.1
  Using cached executing-2.0.0-py2.py3-none-any.whl (24 kB)
Collecting asttokens>=2.0.1
  Using cached asttokens-2.4.0-py2.py3-none-any.whl (27 kB)
Collecting six>=1.12.0
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting typing; python_version < "3.5"
  Using cached typing-3.10.0.0-py2-none-any.whl (26 kB)
Installing collected packages: colorama, pygments, executing, six, typing, asttokens, icecream
  Running setup.py develop for icecream
Successfully installed asttokens-2.4.0 colorama-0.4.6 executing-2.0.0 icecream pygments-2.5.2 six-1.16.0 typing-3.10.0.0

(.venv2) 
$ python2
Python 2.7.18 (default, Jun  8 2023, 11:35:23) 
[GCC Apple LLVM 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.

>>> import icecream
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "icecream/__init__.py", line 15, in <module>
    from .icecream import *  # noqa
  File "icecream/icecream.py", line 28, in <module>
    import executing
  File "/Users/justinb/projects.opensource/icecream/.venv2/lib/python2.7/site-packages/executing/__init__.py", line 12, in <module>
    from .executing import Source, Executing, only, NotOneValueFound, cache, future_flags
  File "/Users/justinb/projects.opensource/icecream/.venv2/lib/python2.7/site-packages/executing/executing.py", line 36, in <module>
    from functools import lru_cache
ImportError: cannot import name lru_cache
>>> 
```

From the above, note the installation of `executing`:
```
Collecting executing>=0.3.1
  Using cached executing-2.0.0-py2.py3-none-any.whl (24 kB)
```

Now with this PR's change:
```
$ deactivate

$ rm -rf .venv2

$ git checkout limit-executing-version 
Switched to branch 'limit-executing-version'
Your branch is up to date with 'github/limit-executing-version'.

$ python2 -m virtualenv .venv2
created virtual environment CPython2.7.18.final.0-64 in 380ms
  creator CPython2Posix(dest=/Users/justinb/projects.opensource/icecream/.venv2, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, wheel=bundle, setuptools=bundle, via=copy, app_data_dir=/Users/justinb/Library/Application Support/virtualenv)
    added seed packages: pip==20.3.4, setuptools==44.1.1, wheel==0.37.1
  activators NushellActivator,PythonActivator,FishActivator,CShellActivator,PowerShellActivator,BashActivator

$ source .venv2/bin/activate

(.venv2) 
$ python2 -m pip install -e .
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Obtaining file:///Users/justinb/projects.opensource/icecream
Collecting colorama>=0.3.9
  Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting pygments>=2.2.0
  Using cached Pygments-2.5.2-py2.py3-none-any.whl (896 kB)
Collecting executing<2.0.0,>=0.3.1
  Using cached executing-1.2.0-py2.py3-none-any.whl (24 kB)
Collecting asttokens>=2.0.1
  Using cached asttokens-2.4.0-py2.py3-none-any.whl (27 kB)
Collecting typing; python_version < "3.5"
  Using cached typing-3.10.0.0-py2-none-any.whl (26 kB)
Collecting six>=1.12.0
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: colorama, pygments, typing, executing, six, asttokens, icecream
  Running setup.py develop for icecream
Successfully installed asttokens-2.4.0 colorama-0.4.6 executing-1.2.0 icecream pygments-2.5.2 six-1.16.0 typing-3.10.0.0

(.venv2) 
$ python2
Python 2.7.18 (default, Jun  8 2023, 11:35:23) 
[GCC Apple LLVM 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import icecream
>>> icecream.install()
```

From the above, note the installation of `executing`:
```
Collecting executing<2.0.0,>=0.3.1
  Using cached executing-1.2.0-py2.py3-none-any.whl (24 kB)
```
