### PR TITLE
disableColoring and enableColoring methods added to IceCreamDebugger closes#155

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
             toxenv: py38
           - python-version: 3.9
             toxenv: py39
-          - python-version: pypy-2.7
-            toxenv: pypy
           - python-version: pypy-3.7
             toxenv: pypy3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 2.7
-            toxenv: py27
           - python-version: 3.5
             toxenv: py35
           - python-version: 3.6

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 *.pyo
 *.egg
 *.egg-info
+.vscode

--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ ic| 3: 3
 `ic()` continues to return its arguments when disabled, of course; no existing
 code with `ic()` breaks.
 
+Finally, by default `ic()` will produce an output with coloring. Colored output can be disabled and enabled.
+
+```
+ic.disableColoring()
+
+ic.enableColoring()
+
+```
+
 
 ### Import Tricks
 

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -369,6 +369,20 @@ class IceCreamDebugger:
         
         if contextAbsPath is not _absent:
             self.contextAbsPath = contextAbsPath
+    
+    def disableColoring(self):
+        """Disable color output by rerouting outputFunction to sys.stderr"""
+
+        self.color_outputFunction = self.outputFunction
+        self.outputFunction = stderrPrint
+
+    def enableColoring(self):
+        """Renable color output by restoring original output function"""
+
+        # Check if color_outputFunction has been set already.
+        # If not then coloring hasn't been disabled so do nothing
+        if hasattr(self, "color_outputFunction"):
+            self.outputFunction = self.color_outputFunction
 
 
 ic = IceCreamDebugger()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pypy, pypy3
+envlist = py35, py36, py37, py38, py39, pypy, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
```
ic.disableColoring()
ic.enableColoring()
```

Based on this context manger taken from the unittests:
```
@contextmanager
def disableColoring():
    originalOutputFunction = ic.outputFunction

    ic.configureOutput(outputFunction=stderrPrint)
    yield
    ic.configureOutput(outputFunction=originalOutputFunction)
```


Note: I had to modify tox.ini and ci.yml to make the tests pass due to deprecated support for python 2.7