### PR TITLE
IceCreamDebugger: configureOutput: allow custom lineWrapWidth value

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -349,7 +349,7 @@ class IceCreamDebugger:
 
     def configureOutput(self, prefix=_absent, outputFunction=_absent,
                         argToStringFunction=_absent, includeContext=_absent,
-                        contextAbsPath=_absent):
+                        contextAbsPath=_absent, lineWrapWidth=_absent):
         noParameterProvided = all(
             v is _absent for k,v in locals().items() if k != 'self')
         if noParameterProvided:
@@ -369,6 +369,9 @@ class IceCreamDebugger:
         
         if contextAbsPath is not _absent:
             self.contextAbsPath = contextAbsPath
+
+        if lineWrapWidth is not _absent:
+            self.lineWrapWidth = lineWrapWidth
 
 
 ic = IceCreamDebugger()


### PR DESCRIPTION
Today lineWrapWidth is set to 70, which can be annoying in some situation. This patch exposes lineWrapWidth through the configureOutput method.

Usage:
```python
ic.configureOutput(lineWrapWidth=42)
```