### PR TITLE
Remove vestigial import

### DIFF
--- a/icecream/__init__.py
+++ b/icecream/__init__.py
@@ -10,8 +10,6 @@
 # License: MIT
 #
 
-from os.path import dirname, join as pjoin
-
 from .icecream import *  # noqa
 from .builtins import install, uninstall
 


### PR DESCRIPTION
Added in c25441c339385d346e8505a52cecd05e65473db3 to support actual usage with the file but when the usage was removed in c6d7e8f70f928d7309de7327bd9c223aab25718f the import remained.