### PR TITLE
fix pycharm/pytest output in linux

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -61,9 +61,10 @@ def colorize(s):
 def supportTerminalColorsInWindows():
     # Filter and replace ANSI escape sequences on Windows with equivalent Win32
     # API calls. This code does nothing on non-Windows systems.
-    colorama.init()
+    __tmp = sys.platform.startswith('win')
+    if __tmp: colorama.init()
     yield
-    colorama.deinit()
+    if __tmp: colorama.deinit()
 
 
 def stderrPrint(*args):


### PR DESCRIPTION
This commit patches the testing framework coloring output in Pycharm (Pytest at least).
Edit highlighting settings in IDE to configure default stderr in place.
This pull is also useful https://github.com/gruns/icecream/pull/170 to easily change stream's output.

* View discussion in https://github.com/gruns/icecream/pull/40