### PR TITLE
Make `ic` a function instead of an instance to improve distinction and intuitiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+This is a fork repo of [gruns](https://github.com/gruns)'s [icecream](https://github.com/gruns/icecream).
+
+Refactor implementation method of `ic`, changing it from an instance to a function, improving visibility and intuitiveness in the users' IDE.
+
+Installing this fork with pip:
+```
+$ pip install git+https://github.com/YunfangHou/icecream.git
+```
+
+Below is the original readme file.
+
 <h1 align="center">
   <img src="logo.svg" width="220px" height="370px" alt="icecream">
 </h1>

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -205,19 +205,19 @@ class IceCreamDebugger:
         self.argToStringFunction = argToStringFunction
         self.contextAbsPath = contextAbsPath
 
-    def __call__(self, *args):
-        if self.enabled:
-            callFrame = inspect.currentframe().f_back
-            self.outputFunction(self._format(callFrame, *args))
+    # def __call__(self, *args):
+    #     if self.enabled:
+    #         callFrame = inspect.currentframe().f_back
+    #         self.outputFunction(self._format(callFrame, *args))
 
-        if not args:  # E.g. ic().
-            passthrough = None
-        elif len(args) == 1:  # E.g. ic(1).
-            passthrough = args[0]
-        else:  # E.g. ic(1, 2, 3).
-            passthrough = args
+    #     if not args:  # E.g. ic().
+    #         passthrough = None
+    #     elif len(args) == 1:  # E.g. ic(1).
+    #         passthrough = args[0]
+    #     else:  # E.g. ic(1, 2, 3).
+    #         passthrough = args
 
-        return passthrough
+    #     return passthrough
 
     def format(self, *args):
         callFrame = inspect.currentframe().f_back
@@ -370,4 +370,20 @@ class IceCreamDebugger:
             self.contextAbsPath = contextAbsPath
 
 
-ic = IceCreamDebugger()
+    def ic_aux(self, *args):
+        if self.enabled:
+            callFrame = inspect.currentframe().f_back.f_back
+            self.outputFunction(self._format(callFrame, *args))
+
+        if not args:  # E.g. ic().
+            passthrough = None
+        elif len(args) == 1:  # E.g. ic(1).
+            passthrough = args[0]
+        else:  # E.g. ic(1, 2, 3).
+            passthrough = args
+
+        return passthrough
+    
+def ic(*args):
+    icd_instance = IceCreamDebugger()
+    icd_instance.ic_aux(*args)


### PR DESCRIPTION
resolve https://github.com/gruns/icecream/issues/192

1. A new function `ic_aux`, which is basically as same as the function `__call__`, but adding one more `f_back` after `callFrame = inspect.currentframe().f_back`, because `ic_aux` is invoked one more level of function.
2. A new independent function `ic`, which initializes an instance of `IceCreamDebugger` and invokes the `ic_aux` function of the instance.
3. Comment out `__call__` function in `IceCreamDebugger`.

The effect is shown in the image below. The `ic` is now highlighted in the color of a function, with higher distinction and intuitiveness in user's IDE.

<img width="608" alt="image" src="https://github.com/user-attachments/assets/35075d43-968d-4b80-af7d-35032e75feee">
