### PR TITLE
Fixed issue in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ stderr (the default).
 >>> from icecream import ic
 >>>
 >>> def warn(s):
->>>     logging.warning(s)
+>>>     logging.warning("%s", s)
 >>>
 >>> ic.configureOutput(outputFunction=warn)
 >>> ic('eep')


### PR DESCRIPTION
Logging interpolates its arguments, so to log a string without surprises one needs `logging.warning("%s", s)`, not `logging.warning(s)`.

This fixes the example in the README accordingly.