### PR TITLE
disable sorting on TypeError by default.

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -81,11 +81,7 @@ def colorizedStderrPrint(s):
         stderrPrint(colored)
 
 
-DEFAULT_PREFIX = 'ic| '
-DEFAULT_LINE_WRAP_WIDTH = 70  # Characters.
-DEFAULT_CONTEXT_DELIMITER = '- '
-DEFAULT_OUTPUT_FUNCTION = colorizedStderrPrint
-def DEFAULT_ARG_TO_STRING_FUNCTION(*args, **kwargs): 
+def pformatWithFallback(*args, **kwargs): 
   try:
     return pprint.pformat(*args, **kwargs)
   except TypeError as e:
@@ -93,6 +89,13 @@ def DEFAULT_ARG_TO_STRING_FUNCTION(*args, **kwargs):
     kwargs = kwargs.copy()
     kwargs["sort_dicts"] = False
     return pprint.pformat(*args, **kwargs)
+
+
+DEFAULT_PREFIX = 'ic| '
+DEFAULT_LINE_WRAP_WIDTH = 70  # Characters.
+DEFAULT_CONTEXT_DELIMITER = '- '
+DEFAULT_OUTPUT_FUNCTION = colorizedStderrPrint
+DEFAULT_ARG_TO_STRING_FUNCTION = pformat_with_fallback
 
 """
 This info message is printed instead of the arguments when icecream

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -85,8 +85,14 @@ DEFAULT_PREFIX = 'ic| '
 DEFAULT_LINE_WRAP_WIDTH = 70  # Characters.
 DEFAULT_CONTEXT_DELIMITER = '- '
 DEFAULT_OUTPUT_FUNCTION = colorizedStderrPrint
-DEFAULT_ARG_TO_STRING_FUNCTION = pprint.pformat
-
+def DEFAULT_ARG_TO_STRING_FUNCTION(*args, **kwargs): 
+  try:
+    return pprint.pformat(*args, **kwargs)
+  except TypeError as e:
+    warnings.warn(f"pprint failed to print: {e}; trying without sorting" )
+    kwargs = kwargs.copy()
+    kwargs["sort_dicts"] = False
+    return pprint.pformat(*args, **kwargs)
 
 """
 This info message is printed instead of the arguments when icecream


### PR DESCRIPTION
Really sloppy solution, with a sloppy implementation; but it works.  Couldn't think of any other way to do this, and it has the additional feature of being possible to override by the user.
fixes #199.

Feel free to reject.