### PR TITLE
Update setup.py to not include tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'Information and documentation can be found at '
         'https://github.com/gruns/icecream.'),
     platforms=['any'],
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     classifiers=[
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
The `tests` directory should _not_ be included in the module.

If merged, this pull-request fixes #203 
