### PR TITLE
make ic's install configurable before installation

### DIFF
--- a/icecream/builtins.py
+++ b/icecream/builtins.py
@@ -10,13 +10,16 @@
 # License: MIT
 #
 
+from typing import Optional
 import icecream
 
 builtins = __import__('builtins')
 
 
-def install(ic: str='ic') -> None:
-    setattr(builtins, ic, icecream.ic)
+def install(ic: str='ic', configured_ic: Optional[icecream.IceCreamDebugger] = None) -> None:
+    if configured_ic is None:
+        configured_ic = icecream.ic
+    setattr(builtins, ic, configured_ic)
 
 
 def uninstall(ic: str='ic') -> None:


### PR DESCRIPTION
## Overview

Refactored `install()` function to support pre-configured Icecream instances.

## Changes

**Functionality:**
   - Maintains full backward compatibility
   - Allows passing custom-configured `ic` instances (e.g., with modified prefix/output settings)

## Usage Example

```python
from icecream import ic

# Install with custom name and configured instance
my_ic = ic.configureOutput(prefix='DEBUG: ')
install(configured_ic=my_ic)
```