### PR TITLE
build: exclude test folder from package build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE.txt README.md
+prune tests


### PR DESCRIPTION
Without this the tests/ folder is included, which will shadow a local tests/ directory.
