### PR TITLE
Fix Japanese character encoding issue #222

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -49,10 +49,21 @@ def bindStaticVariable(name: str, value: Any) -> Callable:
     return decorator
 
 
+def has_non_ascii_chars(s: str) -> bool:
+    """Check if string contains non-ASCII characters."""
+    return any(ord(char) > 127 for char in s)
+
+
 @bindStaticVariable('formatter', Terminal256Formatter(style=SolarizedDark))
 @bindStaticVariable('lexer', Py3Lexer(ensurenl=False))
 def colorize(s: str) -> str:
     self = colorize
+    
+    # Skip syntax highlighting for strings with non-ASCII characters to avoid
+    # encoding issues with pygments (fixes issue #222)
+    if has_non_ascii_chars(s):
+        return s
+    
     return highlight(
         s,
         cast(Py3Lexer, self.lexer),

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -199,8 +199,8 @@ def formatPair(prefix: str, arg: Union[str, Sentinel], value: str) -> str:
 class _SingleDispatchCallable:
     def __call__(self, *args: object) -> str:
         # This is a marker class, not a real thing you should use
-        raise NotImplemented
-    
+        raise NotImplementedError("This is a marker class, not a real thing you should use")
+
     register: Callable[[Type], Callable]
 
 

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -21,6 +21,7 @@ from os.path import basename, splitext, realpath
 
 import icecream
 from icecream import ic, argumentToString, stderrPrint, NO_SOURCE_AVAILABLE_WARNING_MESSAGE
+from icecream.icecream import has_non_ascii_chars
 
 TEST_PAIR_DELIMITER = '| '
 MY_FILENAME = basename(__file__)
@@ -666,6 +667,30 @@ ic| (a,
         self.assertIn("ic|", s)
         self.assertIn("hello", s)
         self.assertIn("world", s)
+
+    def test_non_ascii_characters_no_syntax_highlighting(self):
+        """Test that non-ASCII characters skip syntax highlighting to avoid encoding issues."""
+        # Test the helper function
+        self.assertTrue(has_non_ascii_chars('Hello 世界'))
+        self.assertTrue(has_non_ascii_chars('Привет мир'))
+        self.assertFalse(has_non_ascii_chars('Hello World'))
+        self.assertFalse(has_non_ascii_chars('123 ABC'))
+        
+        # Test that non-ASCII strings don't get ANSI escape codes (no syntax highlighting)
+        with captureStandardStreams() as (out, err):
+            ic('Hello 世界')
+        
+        output = err.getvalue()
+        self.assertIn('Hello 世界', output)
+        self.assertFalse(hasAnsiEscapeCodes(output))  # No syntax highlighting
+        
+        # Test that ASCII strings still get syntax highlighting
+        with captureStandardStreams() as (out, err):
+            ic('Hello World')
+        
+        output = err.getvalue()
+        self.assertIn('Hello World', output)
+        self.assertTrue(hasAnsiEscapeCodes(output))  # Has syntax highlighting
 
     def test_sympy_solve_result_does_not_crash(self):
         """Regression: ic() must handle SymPy solve() outputs."""


### PR DESCRIPTION
- Add has_non_ascii_chars() helper function to detect Unicode strings
- Skip syntax highlighting for strings with non-ASCII characters to avoid encoding issues with pygments that cause corrupted ANSI escape sequences
- Japanese and other Unicode characters now display correctly
- ASCII strings still get proper syntax highlighting
- Fixes issue where ic() output contained corrupted ANSI codes like '�[38;5;247mic[39m'

Fixes #222