### PR TITLE
build: exclude tests sub-packages from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'Information and documentation can be found at '
         'https://github.com/gruns/icecream.'),
     platforms=['any'],
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     package_data={'icecream': ['py.typed']},
     classifiers=[


### PR DESCRIPTION
follow-up on https://github.com/gruns/icecream/commit/2977c4c64276e25d7c094e72d1807fd57b370d22

I learned something about the Python build system on this one. Apparently wheels do not use the same build system as the targzip that's uploaded to PyPy. This change excludes the test folder from wheels as well.
