### PR TITLE
tests: use regex for ANSI escape code detection in has_ansi_escape_codes()

### DIFF
--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -10,6 +10,7 @@
 # License: MIT
 #
 
+import re
 import sys
 import unittest
 import warnings
@@ -37,9 +38,10 @@ def noop(*args, **kwargs):  # type: ignore
     return
 
 
+_ANSI_CSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')
+
 def has_ansi_escape_codes(s: str) -> bool:
-    # oversimplified, but ¯\_(ツ)_/¯. TODO(grun): Test with regex.
-    return '\x1b[' in s
+    return bool(_ANSI_CSI_RE.search(s))
 
 
 class FakeTeletypeBuffer(StringIO):


### PR DESCRIPTION
Implemented the TODO in tests/test_icecream.py:41 by replacing the oversimplified ANSI escape detection helper with regex-based detection.

Previously has_ansi_escape_codes() only checked for the substring \x1b[, which could produce false positives because it did not validate a complete ANSI CSI escape sequence.

This PR replaces that logic with a precompiled regex that matches full CSI sequences:

_ANSI_CSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')

Changes included:

- Added import re
- Added compiled _ANSI_CSI_RE
- Updated has_ansi_escape_codes() to use regex matching
- Removed resolved TODO(grun) comment

Testing

All existing tests that depend on has_ansi_escape_codes() (test_coloring, test_non_ascii_characters_no_syntax_highlighting, test_no_color_* suite) continue to pass with no modifications.