### PR TITLE
fix: guard against IndexError when repr() returns empty string in formatPair()

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -242,7 +242,7 @@ def formatPair(prefix: str, arg: Union[str, Sentinel], value: str) -> str:
         argLines = prefix_first_line_indent_remaining(prefix, arg)
         valuePrefix = argLines[-1] + ': '
 
-    looksLikeAString = (value[0] + value[-1]) in ["''", '""']
+    looksLikeAString = len(value) >= 2 and (value[0] + value[-1]) in ["''", '""']
     if looksLikeAString:  # Align the start of multiline strings.
         valueLines = prefix_lines(' ', value, startAtLine=1)
         value = '\n'.join(valueLines)


### PR DESCRIPTION
## Bug

`formatPair()` accesses `value[0]` unconditionally to check whether the stringified value looks like a Python string literal. When an object's `__repr__` returns an empty string `''`, this raises `IndexError: string index out of range` whenever output is formatted across multiple lines (triggered by a long prefix, a long line, or a multiline value).

## Reproduction

```python
from icecream import ic

class EmptyRepr:
    def __repr__(self):
        return ''

ic.configureOutput(prefix='x' * 100)  # force multiline path
ic(EmptyRepr())  # IndexError: string index out of range
```

## Fix

Add a `len(value) >= 2` guard before the character-index access so that empty (and single-character) strings skip the string-literal check instead of crashing.

```python
# Before
looksLikeAString = (value[0] + value[-1]) in ["''", '""']

# After
looksLikeAString = len(value) >= 2 and (value[0] + value[-1]) in ["''", '""']
```