### PR TITLE
test: cover empty/single-char repr in multiline output; fix remaining IndexError

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -230,6 +230,8 @@ def prefix_lines(prefix: str, s: str, startAtLine: int = 0) -> List[str]:
 def prefix_first_line_indent_remaining(prefix: str, s: str) -> List[str]:
     indent = ' ' * len(prefix)
     lines = prefix_lines(indent, s, startAtLine=1)
+    if not lines:  # E.g. an empty string from a repr() returning ''.
+        return [prefix]
     lines[0] = prefix + lines[0]
     return lines
 
@@ -242,7 +244,7 @@ def formatPair(prefix: str, arg: Union[str, Sentinel], value: str) -> str:
         argLines = prefix_first_line_indent_remaining(prefix, arg)
         valuePrefix = argLines[-1] + ': '
 
-    looksLikeAString = (value[0] + value[-1]) in ["''", '""']
+    looksLikeAString = len(value) >= 2 and (value[0] + value[-1]) in ["''", '""']
     if looksLikeAString:  # Align the start of multiline strings.
         valueLines = prefix_lines(' ', value, startAtLine=1)
         value = '\n'.join(valueLines)

--- a/tests/test_icecream.py
+++ b/tests/test_icecream.py
@@ -494,6 +494,27 @@ class TestIceCream(unittest.TestCase):
         pair = parse_output_into_pairs(out, err, 3)[1][0]
         assert pair == ('multilineStr', ic.argToStringFunction(multilineStr))
 
+    def test_empty_repr_multiline_output_no_crash(self):
+        # Regression test for https://github.com/gruns/icecream/pull/240:
+        # formatPair() indexed value[0] unconditionally, which raised
+        # IndexError on multiline output when repr() returned an empty string.
+        class EmptyRepr:
+            def __repr__(self):
+                return ''
+
+        class SingleCharRepr:
+            def __repr__(self):
+                return 'x'
+
+        with configure_icecream_output(prefix='p' * 100):  # Force multiline output.
+            with disable_coloring(), capture_standard_streams() as (out, err):
+                ic(EmptyRepr())
+                ic(SingleCharRepr())
+
+        output = err.getvalue()
+        assert 'EmptyRepr' in output
+        assert 'SingleCharRepr' in output
+
     def test_format(self):
         with disable_coloring(), capture_standard_streams() as (out, err):
             """comment"""; noop(); ic(  # noqa


### PR DESCRIPTION
Follow-up to #240 — the tests @Jakeroid asked for, plus one more fix they surfaced.

While writing the tests I found that #240's guard fixes the string-literal check, but an empty repr() still crashes on the multiline path further down: prefix_first_line_indent_remaining() indexes lines[0] on the empty list that ''.splitlines() produces.

Changes:
- icecream.py: prefix_first_line_indent_remaining() returns [prefix] when the value has no lines (empty repr).
- test_icecream.py: regression test covering both an empty repr and a single-char repr under multiline output (forced via a long prefix).
Repro that still failed after #240:

    from icecream import ic
    class EmptyRepr:
        def __repr__(self): return ''
    ic.configureOutput(prefix='x' * 100)
    ic(EmptyRepr())  # IndexError: string index out of range

Test suite passes locally apart from two pre-existing failures unrelated to this change (test_enable_disable, test_singledispatch_argument_to_string).