### PR TITLE
Allow callable prefixes in configureOutput type annotation

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -483,7 +483,7 @@ class IceCreamDebugger:
 
     def configureOutput(
         self: "IceCreamDebugger",
-        prefix: Union[str, Literal[Sentinel.absent]] = Sentinel.absent,
+        prefix: Union[str, Callable[[], str], Literal[Sentinel.absent]] = Sentinel.absent,
         outputFunction: Union[Callable, Literal[Sentinel.absent]] = Sentinel.absent,
         argToStringFunction: Union[Callable, Literal[Sentinel.absent]] = Sentinel.absent,
         includeContext: Union[bool, Literal[Sentinel.absent]] = Sentinel.absent,


### PR DESCRIPTION
## Summary

This PR updates the type annotation for the `prefix` parameter of `configureOutput()` to accept `Callable[[], str]`.

The implementation already supports callable prefixes through `call_or_value()`, but the existing type annotation causes MyPy to report an error when a callable is passed.

### Testing

- Ran `mypy icecream` successfully with no issues.
- Ran `pytest`.
  - 48 tests passed.
  - 1 unrelated Windows-specific test (`test_context_abs_path_multi_line`) failed due to path parsing (`C:\...`), which is unrelated to this type annotation change.

Fixes #241