### PR TITLE
fix: skip colorization when stderr/stdout is not a TTY (#225)

### DIFF
--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -112,14 +112,21 @@ def isLiteral(s: str) -> bool:
     return True
 
 
+def _stream_is_tty(stream: object) -> bool:
+    # isatty() returns True only when the stream is connected to a real
+    # terminal (not a pipe, file redirect, or captured output).  We guard
+    # with hasattr() because some custom stream objects omit the method.
+    return hasattr(stream, 'isatty') and bool(getattr(stream, 'isatty')())
+
+
 def colorizedStderrPrint(s: str) -> None:
-    colored = colorize(s) if hasattr(sys.stderr, 'isatty') and sys.stderr.isatty() else s
+    colored = colorize(s) if _stream_is_tty(sys.stderr) else s
     with supportTerminalColorsInWindows():
         stderr_print(colored)
 
 
 def colorizedStdoutPrint(s: str) -> None:
-    colored = colorize(s) if hasattr(sys.stdout, 'isatty') and sys.stdout.isatty() else s
+    colored = colorize(s) if _stream_is_tty(sys.stdout) else s
     with supportTerminalColorsInWindows():
         print(colored)
 

--- a/icecream/icecream.py
+++ b/icecream/icecream.py
@@ -113,13 +113,13 @@ def isLiteral(s: str) -> bool:
 
 
 def colorizedStderrPrint(s: str) -> None:
-    colored = colorize(s)
+    colored = colorize(s) if hasattr(sys.stderr, 'isatty') and sys.stderr.isatty() else s
     with supportTerminalColorsInWindows():
         stderr_print(colored)
 
 
 def colorizedStdoutPrint(s: str) -> None:
-    colored = colorize(s)
+    colored = colorize(s) if hasattr(sys.stdout, 'isatty') and sys.stdout.isatty() else s
     with supportTerminalColorsInWindows():
         print(colored)
 


### PR DESCRIPTION
## Problem

Fixes #225.

`colorizedStderrPrint` and `colorizedStdoutPrint` always colorize their output by calling
`colorize()` unconditionally. `colorize()` uses Pygments, which emits ANSI escape sequences.
When `sys.stderr` (or `sys.stdout`) is **redirected to a file**, the stream is not a TTY and
those escape sequences appear as literal garbage in the captured output:

```
\x1b[38;5;240mic\x1b[0m| x: 42
```

The user expected `ic| x: 42`.

### Root Cause

Neither function contains an `isatty()` check:

```python
# before (current)
def colorizedStderrPrint(s: str) -> None:
    colored = colorize(s)          # always emits ANSI — no TTY check
    with supportTerminalColorsInWindows():
        stderr_print(colored)
```

This worked in 2.1.4 because Pygments' older formatter default respected
terminal detection, but a change in icecream's Pygments usage removed that
implicit guard.

## Fix

Add an `isatty()` guard in both print functions:

```python
# after
def colorizedStderrPrint(s: str) -> None:
    colored = colorize(s) if hasattr(sys.stderr, 'isatty') and sys.stderr.isatty() else s
    with supportTerminalColorsInWindows():
        stderr_print(colored)

def colorizedStdoutPrint(s: str) -> None:
    colored = colorize(s) if hasattr(sys.stdout, 'isatty') and sys.stdout.isatty() else s
    with supportTerminalColorsInWindows():
        print(colored)
```

`hasattr(..., 'isatty')` guards against custom stream objects that might not implement `isatty`.

## Verification

```bash
# With color (TTY, unchanged behavior)
python -c "from icecream import ic; ic(42)"
# ic| 42                  ← colored in terminal

# Without color (redirected, previously broken)
python -c "from icecream import ic; ic(42)" 2>&1 | cat
# ic| 42                  ← plain text, no escape sequences
```
